### PR TITLE
Automated bump version workflow needs bumpversion config file in tudat-feedstock

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,20 @@
+[bumpversion]
+current_version = 2.13.0.dev19
+commit = True
+tag = True
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<release>[a-z]+)(?P<dev>\d+))?
+serialize =
+	{major}.{minor}.{patch}.{release}{dev}
+	{major}.{minor}.{patch}
+
+[bumpversion:part:release]
+optional_value = gamma
+values =
+	dev
+	gamma
+
+[bumpversion:part:dev]
+
+[bumpversion:file:recipe/meta.yaml]
+search = version = "{current_version}"
+replace = version = "{new_version}"

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 /build_artifacts
 
 *.pyc
+
+# allow bumpversion config file to be versioned
+!.bumpversion.cfg

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,8 @@
 {% set name = "tudat" %}
   {% set version = "2.13.0.dev19" %}
   {% set build = "0" %}
-  {% set git_rev = "v2.13.0.dev19" %}
+  {% set git_rev = "v" + version %} # git_rev must point to the version tag. Hardcoded version can be replaced by assigning it using the version variable.This also solves formatting and indenantion issues while using the bumpversion command.
+
 
 package:
   name: {{ name }}
@@ -25,7 +26,7 @@ requirements:
     # Tools required to build the package. These packages are run on the build
     # system and include things such as revision control systems (Git, SVN) make
     # tools (GNU make, Autotool, CMake) and compilers (real cross, pseudo-cross,
-    # or native when not cross-compiling), and any source pre-processors.   
+    # or native when not cross-compiling), and any source pre-processors.
     - {{ compiler('cxx') }}
     - {{ compiler('c') }}
     - cmake


### PR DESCRIPTION
A bump version GitHub actions workflow in tudat (development in progress) will trigger bumping of version in tudat-feedstock. As a result of this, the version in recipe/meta.yml will be updated. 

To accomplish this, a .bumpversion.cfg file is needed that will bump the version in meta.yml via the command `bump2version dev --config-file .bumpversion.cfg --verbose` 

### To do
- [ ] Reset build number in meta.yml when the version is bumped 
- [ ] Before merging the PR, the version must be set to the latest version at that time.

